### PR TITLE
change zoom in shortcut to match expected behavior

### DIFF
--- a/src/main/menus/app.ts
+++ b/src/main/menus/app.ts
@@ -129,7 +129,7 @@ export function createTemplate(config: Config) {
         accelerator: 'CmdOrCtrl+0',
     }, {
         role: 'zoomIn',
-        accelerator: 'CmdOrCtrl+SHIFT+=',
+        accelerator: 'CmdOrCtrl+=',
     }, {
         role: 'zoomOut',
         accelerator: 'CmdOrCtrl+-',


### PR DESCRIPTION
this changes the zoom in shortcut to match the behavior that other apps like chrome and firefox use. (ctrl+= to zoom in)